### PR TITLE
Fix media queries issue for the index / add fullscreen capability

### DIFF
--- a/BakerView/BakerBook.h
+++ b/BakerView/BakerBook.h
@@ -67,6 +67,7 @@
 @property (copy, nonatomic) NSNumber *bakerPageTurnSwipe;
 @property (copy, nonatomic) NSNumber *bakerMediaAutoplay;
 
+@property (copy, nonatomic) NSNumber *bakerIndexFullscreen;
 @property (copy, nonatomic) NSNumber *bakerIndexWidth;
 @property (copy, nonatomic) NSNumber *bakerIndexHeight;
 @property (copy, nonatomic) NSNumber *bakerIndexBounce;

--- a/BakerView/BakerBook.m
+++ b/BakerView/BakerBook.m
@@ -68,6 +68,7 @@
 @synthesize bakerPageTurnSwipe;
 @synthesize bakerMediaAutoplay;
 
+@synthesize bakerIndexFullscreen;
 @synthesize bakerIndexWidth;
 @synthesize bakerIndexHeight;
 @synthesize bakerIndexBounce;
@@ -198,6 +199,7 @@
     self.bakerPageTurnSwipe      = [bookData objectForKey:@"-baker-page-turn-swipe"];
     self.bakerMediaAutoplay      = [bookData objectForKey:@"-baker-media-autoplay"];
 
+    self.bakerIndexFullscreen  = [bookData objectForKey:@"-baker-index-fullscreen"];
     self.bakerIndexWidth  = [bookData objectForKey:@"-baker-index-width"];
     self.bakerIndexHeight = [bookData objectForKey:@"-baker-index-height"];
     self.bakerIndexBounce = [bookData objectForKey:@"-baker-index-bounce"];
@@ -246,6 +248,9 @@
 
     if (self.bakerIndexBounce == nil) {
         self.bakerIndexBounce = [NSNumber numberWithBool:NO];
+    }
+    if (self.bakerIndexFullscreen == nil) {
+        self.bakerIndexFullscreen = [NSNumber numberWithBool:NO];
     }
     if (self.bakerStartAtPage == nil) {
         self.bakerStartAtPage = [NSNumber numberWithInt:1];
@@ -363,6 +368,7 @@
                                                         @"-baker-page-turn-tap",
                                                         @"-baker-page-turn-swipe",
                                                         @"-baker-media-autoplay",
+                                                        @"-baker-index-fullscreen",
                                                         @"-baker-index-width",
                                                         @"-baker-index-height",
                                                         @"-baker-index-bounce",
@@ -461,6 +467,7 @@
     [bakerPageTurnSwipe release];
     [bakerMediaAutoplay release];
 
+    [bakerIndexFullscreen release];
     [bakerIndexWidth release];
     [bakerIndexHeight release];
     [bakerIndexBounce release];

--- a/BakerView/IndexViewController.h
+++ b/BakerView/IndexViewController.h
@@ -46,6 +46,7 @@
     int actualIndexWidth;
     int actualIndexHeight;
 
+    BOOL fullscreen;
     BOOL disabled;
     BOOL loadedFromBundle;
 
@@ -59,6 +60,7 @@
 - (void)setBounceForWebView:(UIWebView *)webView bounces:(BOOL)bounces;
 - (void)setPageSizeForOrientation:(UIInterfaceOrientation)orientation;
 - (BOOL)isIndexViewHidden;
+- (BOOL)isFullscreen;
 - (BOOL)isDisabled;
 - (void)setIndexViewHidden:(BOOL)hidden withAnimation:(BOOL)animation;
 - (void)willRotate;

--- a/BakerView/IndexViewController.m
+++ b/BakerView/IndexViewController.m
@@ -45,6 +45,7 @@
         webViewDelegate = delegate;
 
         disabled = NO;
+        fullscreen = [self isFullscreen];
         indexWidth = 0;
         indexHeight = 0;
 
@@ -105,12 +106,22 @@
 }
 
 - (void)setActualSize {
-    actualIndexWidth = MIN(indexWidth, pageWidth);
-    actualIndexHeight = MIN(indexHeight, pageHeight);
+    if (fullscreen) {
+        actualIndexWidth = pageWidth;
+        actualIndexHeight = pageHeight;
+    } else {
+        actualIndexWidth = MIN(indexWidth, pageWidth);
+        actualIndexHeight = MIN(indexHeight, pageHeight);
+    }
+    
 }
 
 - (BOOL)isIndexViewHidden {
     return [UIApplication sharedApplication].statusBarHidden;
+}
+
+- (BOOL)isFullscreen {
+    return (BOOL)[book.bakerIndexFullscreen boolValue];
 }
 
 - (BOOL)isDisabled {
@@ -129,7 +140,7 @@
         if ([self stickToLeft]) {
             frame = CGRectMake(0, [self trueY] + pageHeight - actualIndexHeight, actualIndexWidth, actualIndexHeight);
         } else {
-            frame = CGRectMake(0, [self trueY] + pageHeight - indexHeight, actualIndexWidth, actualIndexHeight);
+            frame = CGRectMake(0, [self trueY] + pageHeight - actualIndexHeight, actualIndexWidth, actualIndexHeight);
         }
 
     }
@@ -221,18 +232,20 @@
     }
 }
 -(void)webViewDidFinishLoad:(UIWebView *)webView {
-    id width = book.bakerIndexWidth;
-    id height = book.bakerIndexHeight;
+    if (!fullscreen) {
+        id width = book.bakerIndexWidth;
+        id height = book.bakerIndexHeight;
 
-    if (width != nil) {
-        indexWidth = (int)[width integerValue];
-    } else {
-        indexWidth = [self sizeFromContentOf:webView].width;
-    }
-    if (height != nil) {
-        indexHeight = (int)[height integerValue];
-    } else {
-        indexHeight = [self sizeFromContentOf:webView].height;
+        if (width != nil) {
+            indexWidth = (int)[width integerValue];
+        } else {
+            indexWidth = [self sizeFromContentOf:webView].width;
+        }
+        if (height != nil) {
+            indexHeight = (int)[height integerValue];
+        } else {
+            indexHeight = [self sizeFromContentOf:webView].height;
+        }
     }
 
     cachedContentSize = indexScrollView.contentSize;
@@ -251,6 +264,9 @@
 }
 
 - (BOOL)stickToLeft {
+    if (fullscreen) {
+        return NO;
+    }
     return (actualIndexHeight > actualIndexWidth);
 }
 


### PR DESCRIPTION
Add a new extension parameter: -baker-index-fullscreen

It forces the index view to use the size of the screen instead of the size needed by its content.
That way, you can use media queries for the index. Reference: [issue 637](https://github.com/Simbul/baker/issues/637).

You can also design an index that is not visually fullscreen (with a transparent background).

The index can be closed with a double-tap.
