### PR TITLE
Added customisable sharing via native share widget

### DIFF
--- a/Baker.xcodeproj/project.pbxproj
+++ b/Baker.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		BF0785EB1794AF4000EB988E /* info in Resources */ = {isa = PBXBuildFile; fileRef = BF0785EA1794AF4000EB988E /* info */; };
 		BF78D1B0180C8F070093DFBC /* BakerAssets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = BF78D1AF180C8F070093DFBC /* BakerAssets.xcassets */; };
 		BFAB78D317B2A67E00E91ADE /* BakerAnalyticsEvents.m in Sources */ = {isa = PBXBuildFile; fileRef = BFAB78D217B2A67E00E91ADE /* BakerAnalyticsEvents.m */; };
+		FA338F671874C4890025A140 /* SharePage.m in Sources */ = {isa = PBXBuildFile; fileRef = FA338F661874C4890025A140 /* SharePage.m */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -146,6 +147,8 @@
 		BF78D1AF180C8F070093DFBC /* BakerAssets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; name = BakerAssets.xcassets; path = Baker/BakerAssets.xcassets; sourceTree = "<group>"; };
 		BFAB78D117B2A67E00E91ADE /* BakerAnalyticsEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BakerAnalyticsEvents.h; sourceTree = "<group>"; };
 		BFAB78D217B2A67E00E91ADE /* BakerAnalyticsEvents.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BakerAnalyticsEvents.m; sourceTree = "<group>"; };
+		FA338F651874C4890025A140 /* SharePage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SharePage.h; sourceTree = "<group>"; };
+		FA338F661874C4890025A140 /* SharePage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SharePage.m; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -211,6 +214,8 @@
 				AB40042B15B4B83000D87E2A /* BakerViewController.m */,
 				AB40043315B4B83000D87E2A /* IndexViewController.h */,
 				AB40043415B4B83000D87E2A /* IndexViewController.m */,
+				FA338F651874C4890025A140 /* SharePage.h */,
+				FA338F661874C4890025A140 /* SharePage.m */,
 				AB40043515B4B83000D87E2A /* InterceptorWindow.h */,
 				AB40043615B4B83000D87E2A /* InterceptorWindow.m */,
 				AB40044C15B4B83000D87E2A /* ModalViewController.h */,
@@ -434,6 +439,7 @@
 				ABAFB59815AB9A2E002FA498 /* main.m in Sources */,
 				ABAFB59C15AB9A2E002FA498 /* AppDelegate.m in Sources */,
 				AB40045315B4B83000D87E2A /* BakerViewController.m in Sources */,
+				FA338F671874C4890025A140 /* SharePage.m in Sources */,
 				AB40045F15B4B83000D87E2A /* IndexViewController.m in Sources */,
 				AB40046115B4B83000D87E2A /* InterceptorWindow.m in Sources */,
 				AB40046315B4B83000D87E2A /* GTMNSString+HTML.m in Sources */,

--- a/BakerView/BakerViewController.m
+++ b/BakerView/BakerViewController.m
@@ -37,6 +37,8 @@
 #import "SSZipArchive.h"
 #import "PageTitleLabel.h"
 #import "Utils.h"
+#import "SharePage.h"
+
 
 #define INDEX_FILE_NAME         @"index.html"
 
@@ -145,6 +147,14 @@
     [super viewDidLoad];
     self.navigationItem.title = book.title;
     
+    // SOCIAL MEDIA INTEGRATION - START
+    UIBarButtonItem *shareButton = [[[UIBarButtonItem alloc]
+                                     initWithBarButtonSystemItem:UIBarButtonSystemItemAction
+                                     target:self
+                                     action:@selector(shareBtnAction:)]
+                                    autorelease];
+    self.navigationItem.rightBarButtonItem = shareButton;
+    // SOCIAL MEDIA INTEGRATION - END */
     
     // ****** SET THE INITIAL SIZE FOR EVERYTHING
     // Avoids strange animations when opening
@@ -181,6 +191,33 @@
         backgroundImagePortrait = [[UIImage imageWithContentsOfFile:backgroundPathPortrait] retain];
     }
 }
+// SOCIAL MEDIA INTEGRATION - START
+- (void) shareBtnAction:(UIButton *)sender {
+    
+    if (![self checkScreeshotForPage:currentPageNumber andOrientation:[self getCurrentInterfaceOrientation:self.interfaceOrientation]]) {
+        [self takeScreenshotFromView:currPage forPage:currentPageNumber andOrientation:[self getCurrentInterfaceOrientation:self.interfaceOrientation]];
+    }
+    
+    //  How do we get the url?
+    //  we need to work out how to parse the currently viewed page in baker
+    //  then we can run it through libxml, and use xpath to find the following elements
+    //  <meta property="og:title" content="The Rock" />
+    // <meta property="og:url"content="http://www.imdb.com/title/tt0117500/" />
+    
+    // items to share
+    //  NSURL *url = [NSURL URLWithString:@"http://www.thesaturdaypaper.com.au"];
+    NSArray *items =  @[[SharePage getShareTitle:currPage], [SharePage getShareURL:currPage]];
+    
+    
+    // create the controller
+    UIActivityViewController *controller = [[UIActivityViewController alloc]initWithActivityItems:items applicationActivities:nil];
+    
+    // Exclude Irrelevant Parts
+    controller.excludedActivityTypes = @[UIActivityTypePostToWeibo,UIActivityTypePrint,UIActivityTypeCopyToPasteboard,UIActivityTypeAssignToContact,UIActivityTypeSaveToCameraRoll];
+    [self presentViewController:controller animated:YES completion:nil];
+    
+}
+// SOCIAL MEDIA INTEGRATION - END */
 - (void)viewWillAppear:(BOOL)animated {
     
     if (!currentPageWillAppearUnderModal) {

--- a/BakerView/SharePage.h
+++ b/BakerView/SharePage.h
@@ -1,0 +1,17 @@
+//
+//  SharePage.h
+//  thesaturdaypaper
+//
+//  Created by Owen Kelly on 20/12/2013.
+//
+//
+
+#import <Foundation/Foundation.h>
+
+@interface SharePage : NSObject
+
++ (NSString *)getShareTitle:(UIWebView *)webView;
++ (NSString *)getShareURL:(UIWebView *)webView;
+
+
+@end

--- a/BakerView/SharePage.m
+++ b/BakerView/SharePage.m
@@ -1,0 +1,57 @@
+//
+//  SharePage.m
+//  baker
+//
+//  ==========================================================================================
+//
+//  Copyright (c) 2010-2013
+//  All rights reserved.
+//
+//  Redistribution and use in source and binary forms, with or without modification, are
+//  permitted provided that the following conditions are met:
+//
+//  Redistributions of source code must retain the above copyright notice, this list of
+//  conditions and the following disclaimer.
+//  Redistributions in binary form must reproduce the above copyright notice, this list of
+//  conditions and the following disclaimer in the documentation and/or other materials
+//  provided with the distribution.
+//  Neither the name of the Baker Framework nor the names of its contributors may be used to
+//  endorse or promote products derived from this software without specific prior written
+//  permission.
+//  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+//  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+//  OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+//  SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+//  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+//  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+//  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+//  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+//  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+#import "SharePage.h"
+
+@implementation SharePage
+
+//  How to use
+//
+//  Place the following meta tags in the html page in the book. Currently the javascript searches for the first two meta tags on the html.
+//   <meta content="Bring back Firefly." />
+//   <meta content="http://en.wikipedia.org/wiki/Firefly_(TV_series)" />
+
++ (NSString *)getShareTitle:(UIWebView *)webView {
+    // The javascript here returns the value of the content attribute of the 1st meta tag that appears in the html
+    NSString *currentTitle = [webView stringByEvaluatingJavaScriptFromString:@"document.getElementsByTagName('meta')[0].getAttribute('content');"];
+    NSLog(@"Current Title: %@", [currentTitle description]);
+    return currentTitle;
+}
+
++ (NSString *)getShareURL:(UIWebView *)webView {
+    // The javascript here returns the value of the content attribute of the 2nd meta tag that appears in the html
+    NSString *currentURL  = [webView stringByEvaluatingJavaScriptFromString:@"document.getElementsByTagName('meta')[1].getAttribute('content');"];
+    return currentURL;
+}
+
+
+
+@end


### PR DESCRIPTION
Added customisable sharing via native share widget. This code uses the first two meta tags on each html page.

If you customise the javascript found in the getShareTitle and getShareURL methods in SharePage.m you can source the title and URL to share from anywhere in your html, limited only by the javascript you can execute.

---

Based on the work from/fixes:
https://github.com/bakerframework/baker/issues/10
