### PR TITLE
Allow HTML5 Video Autoplay on iPhone

### DIFF
--- a/BakerView/BakerViewController.m
+++ b/BakerView/BakerViewController.m
@@ -601,6 +601,8 @@
     webView.delegate = self;
 
     webView.mediaPlaybackRequiresUserAction = ![book.bakerMediaAutoplay boolValue];
+    // Allow HTML5 video autoplay on iPhone
+    webView.allowsInlineMediaPlayback = YES;
     webView.scalesPageToFit = [book.zoomable boolValue];
     BOOL verticalBounce = [book.bakerVerticalBounce boolValue];
 


### PR DESCRIPTION
For example:

CSS:

```
     .article-video  {
         position:absolute;
         z-index:5;
         overflow:hidden;
         width:768px;
         padding:0px;
         margin-top:0px;
        margin-right: 100px;
   }

     .article-video video {
        height:432px;
       width:768px;
  }
```

HTML: 

```
  <div class="article-start-bg">
       <div class="article-video">
          <video src="video/myVideo.mp4" preload webkit-playsinline></video>
       </div>
  </div>
```
