### PR TITLE
Feature: Dynamic Newsstand Icon

### DIFF
--- a/BakerShelf/Constants.h
+++ b/BakerShelf/Constants.h
@@ -85,6 +85,9 @@
         #define AUTO_RENEWABLE_SUBSCRIPTION_PRODUCT_IDS [NSArray arrayWithObjects: \
             nil]
 
+        // Set newsstand app icon from latest issue
+        // #define SET_NEWSSTAND_LATEST_ISSUE_COVER
+
     #endif
 
     // Timeout for most network requests (in seconds)

--- a/BakerShelf/IssuesManager.m
+++ b/BakerShelf/IssuesManager.m
@@ -87,6 +87,9 @@
                 return [second compare:first];
             }];
             
+            // Update Newsstand Icon
+            [self updateNewsstandIcon];
+            
             if (callback) {
                 callback(YES);
             }
@@ -97,6 +100,33 @@
             }
         }
     }];
+}
+
+-(void)updateNewsstandIcon {
+    
+    #ifdef SET_NEWSSTAND_LATEST_ISSUE_COVER
+        // Get latest issue
+        BakerIssue *latestIssue = nil;
+        for (BakerIssue *issue in self.issues) {
+            // Return if an issue has already been downloaded (in this case the cover image has already been set)
+            if([[issue getStatus] isEqualToString:@"downloaded"]) { return; }
+            // Update latest issue
+            latestIssue = issue;
+            break;
+        }
+        // Set newsstand icon from latest issue
+        NSLog(@"Setting newsstand cover icon from latest issue: %@ at %@", latestIssue.title, latestIssue.date);
+        [latestIssue getCoverWithCache:YES andBlock:^(UIImage *image) {
+            if (image) {
+                [[UIApplication sharedApplication] setNewsstandIconImage:image];
+            }
+        }];
+    #else
+        // Set newsstand icon from newsstand-app-icon
+        UIImage *image = [UIImage imageNamed:@"newsstand-app-icon"];
+        [[UIApplication sharedApplication] setNewsstandIconImage:image];
+    #endif
+    
 }
 
 -(void)getShelfJSON:(void (^)(NSData*)) callback {


### PR DESCRIPTION
## Overview

This feature dynamically sets the latest issues' cover icon as the newsstand icon.
## Use Cases
- When users install your app, they will see the same newsstand icon as they see in app store (which always shows the latest issues icon)
- Fixes a bug for iOS8 where your app will show the wrong icon in newsstand (AppIcon instead of Newsstand Icon)
## Configuration

For setting the newsstand icon to the latest issues' cover image, uncomment the definition of SET_NEWSSTAND_LATEST_ISSUE_COVER in BakerShelf/Constants.h:

```
// Set newsstand app icon from latest issue
#define SET_NEWSSTAND_LATEST_ISSUE_COVER
```
## Bugs / Caveats

None found
