### PR TITLE
Bugfix: layout handling / cell resizing on device rotation

### DIFF
--- a/BakerShelf/BKRShelfViewController.h
+++ b/BakerShelf/BKRShelfViewController.h
@@ -48,6 +48,7 @@
     NSMutableArray *notRecognisedTransactions;
     UIPopoverController *infoPopover;
     BKRPurchasesManager *purchasesManager;
+    UIInterfaceOrientation realInterfaceOrientation;
 }
 
 @property (nonatomic, copy) NSArray *issues;

--- a/BakerShelf/BKRShelfViewController.m
+++ b/BakerShelf/BKRShelfViewController.m
@@ -259,18 +259,32 @@
 }
 
 - (void)willRotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
-    CGSize itemSize = [BKRIssueViewController getIssueCellSizeForOrientation:toInterfaceOrientation];
-    self.layout.itemSize = itemSize;
-    [self.gridView.collectionViewLayout invalidateLayout];
+    realInterfaceOrientation = toInterfaceOrientation;
+    [super willRotateToInterfaceOrientation:toInterfaceOrientation duration:duration];
 }
 
 - (void)willAnimateRotationToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation duration:(NSTimeInterval)duration {
+    [super willAnimateRotationToInterfaceOrientation:toInterfaceOrientation duration:duration];
+
+    // Update label widths
+    [self.issueViewControllers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
+        [(BKRIssueViewController*)obj refreshContentWithCache:NO];
+    }];
+}
+
+- (void)viewDidLayoutSubviews {
+    // Update gradient background (if set)
     if(self.gradientLayer) {
         [self.gradientLayer setFrame:self.gridView.bounds];
     }
+    
+    // Update header size
     [self.layout setHeaderReferenceSize:[self getBannerSize]];
+    
+    // Invalidate layout
+    [self.layout invalidateLayout];
+    
 }
-
 
 - (BKRIssueViewController*)createIssueViewControllerWithIssue:(BKRIssue*)issue {
     BKRIssueViewController *controller = [[BKRIssueViewController alloc] initWithBakerIssue:issue];
@@ -314,8 +328,9 @@
     return cell;
 }
 
+
 - (CGSize)collectionView:(UICollectionView*)collectionView layout:(UICollectionViewLayout*)collectionViewLayout sizeForItemAtIndexPath:(NSIndexPath*)indexPath {
-    return [BKRIssueViewController getIssueCellSizeForOrientation:self.interfaceOrientation];
+    return [BKRIssueViewController getIssueCellSizeForOrientation:realInterfaceOrientation];
 }
 
 - (UICollectionReusableView*)collectionView:(UICollectionView*)collectionView viewForSupplementaryElementOfKind:(NSString*)kind atIndexPath:(NSIndexPath*)indexPath {


### PR DESCRIPTION
With the recent iOS 8 upgrade, there were a couple of scenarios / sdk-versions where the layout did not properly update on rotation.

Although the cell width / height DID update properly after recent changes, the cell's info and title labels did not.

This pull request will fix this bug by taking into account recent iOS behaviour changes. These mainly concern willRotateToInterfaceOrientation and willAnimateRotationToInterfaceOrientation. also, viewDidLayoutSubviews is used to properly wait with layout invalidation until after the device orientation change was fully registered.

Tested on all device / sdk variations.
