### PR TITLE
Allow issue price updates when refreshing the shelf

### DIFF
--- a/BakerShelf/BKRIssueViewController.h
+++ b/BakerShelf/BKRIssueViewController.h
@@ -67,6 +67,8 @@ typedef struct {
 #pragma mark - View Lifecycle
 - (void)refresh;
 - (void)refresh:(NSString*)status;
+- (void)refresh:(NSString*)status cache:(BOOL)cache;
+- (void)refreshWithCache:(BOOL)cache;
 - (void)refreshContentWithCache:(bool)cache;
 - (void)preferredContentSizeChanged:(NSNotification*)notification;
 

--- a/BakerShelf/BKRIssueViewController.m
+++ b/BakerShelf/BKRIssueViewController.m
@@ -258,7 +258,15 @@
 }
 
 - (void)refresh:(NSString*)status {
-    //NSLog(@"[BakerShelf] Shelf UI - Refreshing %@ item with status from <%@> to <%@>", self.issue.ID, self.currentStatus, status);
+    [self refresh:[self.issue getStatus] cache:YES];
+}
+
+- (void)refreshWithCache:(BOOL)cache {
+    [self refresh:[self.issue getStatus] cache:cache];
+}
+
+- (void)refresh:(NSString*)status cache:(BOOL)cache {
+    // NSLog(@"[BakerShelf] Shelf UI - Refreshing %@ item with status from <%@> to <%@>", self.issue.ID, self.currentStatus, status);
     if ([status isEqualToString:@"remote"]) {
         [self.actionButton setTitle:NSLocalizedString(@"FREE_TEXT", nil) forState:UIControlStateNormal];
         [self.spinner stopAnimating];
@@ -351,7 +359,7 @@
         self.loadingLabel.hidden  = NO;
     }
 
-    [self refreshContentWithCache:YES];
+    [self refreshContentWithCache:cache];
 
     self.currentStatus = status;
 }

--- a/BakerShelf/BKRShelfViewController.m
+++ b/BakerShelf/BKRShelfViewController.m
@@ -473,7 +473,7 @@
     [purchasesManager retrievePurchasesFor:[issuesManager productIDs] withCallback:^(NSDictionary *purchases) {
         // List of purchases has been returned, so we can refresh all issues
         [self.issueViewControllers enumerateObjectsUsingBlock:^(id obj, NSUInteger idx, BOOL *stop) {
-            [(BKRIssueViewController*)obj refreshContentWithCache:NO];
+            [(BKRIssueViewController*)obj refreshWithCache:NO];
         }];
         [self setrefreshButtonEnabled:YES];
         


### PR DESCRIPTION
Currently, the shelf issue prices will not refresh when data changes in the backend and the refresh button is pushed. This fix extends the issue view controllers' refreshContentWithCache method(s) and allows the shelf controller to trigger a full refresh (without cache) of the issue views.

Solves:
- Issue price change to free doesn't refresh on shelf on iOS8.1 #363 