### PR TITLE
Bug Fixe - Update BKRPurchasesManager.m

### DIFF
--- a/BakerShelf/BKRPurchasesManager.m
+++ b/BakerShelf/BKRPurchasesManager.m
@@ -330,6 +330,7 @@
     } else {
         NSLog(@"ERROR: Completed transaction for %@, which is not a Product ID this app recognises", productId);
     }
+    [[SKPaymentQueue defaultQueue] finishTransaction:transaction];
 }
 
 - (void)restoreTransaction:(SKPaymentTransaction*)transaction {


### PR DESCRIPTION
This is a fix for a very hard to trace bug.

If a person purchases an issue and is interrupted, either by being prompted to confirm their CC details, or because our server is not available, the transaction will not complete.

According to documentation this line should be there anyway.

Cheers,
Owen
