### PR TITLE
Run cover updates on a background serial thread

### DIFF
--- a/BakerShelf/BKRIssue.m
+++ b/BakerShelf/BKRIssue.m
@@ -235,8 +235,9 @@
         completionBlock(image);
     } else {
         if (self.coverURL) {
-            dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void) {
-                NSData *imageData = [NSData dataWithContentsOfURL:self.coverURL];
+            dispatch_queue_t coverQueue = dispatch_queue_create("Baker Cover Queue", NULL);
+             dispatch_async(coverQueue, ^(void) {
+             NSData *imageData = [NSData dataWithContentsOfURL:self.coverURL];
                 UIImage *image = [UIImage imageWithData:imageData];
                 if (image) {
                     [imageData writeToFile:self.coverPath atomically:YES];


### PR DESCRIPTION
Hi,

We've noticed on large shelves a tendency for the app to lock up.

When updating the cover image, if you have enough items, or the refresh action is called to many times baker spawns more threads than GCD can handle. In my case there was 75 concurrent threads (limit is 64).

Switching this so that all cover updates run on their own serial thread removes this problem.
